### PR TITLE
Fix MongoDB URL variable name mismatch.

### DIFF
--- a/templates/Typescript-MVC/config/Database.ts
+++ b/templates/Typescript-MVC/config/Database.ts
@@ -1,7 +1,7 @@
 import mongoose, { ConnectOptions } from "mongoose";
 
 async function Database() {
-	const URL = process.env.MONG_URL || "";
+	const URL = process.env.MONGO_URI || "";
 	return mongoose.connect(
 		URL,
 		{


### PR DESCRIPTION
This pull request fixes the MongoDB URL variable name mismatch issue.

Hi @iamharshil, can you review the pull request? Thanks